### PR TITLE
Update system.php for modern version of "free" command output.

### DIFF
--- a/includes/system.php
+++ b/includes/system.php
@@ -68,6 +68,13 @@ function DisplaySystem(){
   // mem used
   exec("free -m | awk '/Mem:/ { total=$2 } /buffers\/cache/ { used=$3 } END { print used/total*100}'", $memarray);
   $memused = floor($memarray[0]);
+  // check for memused being unreasonably low, if so repeat expecting modern output of "free" command
+  if ($memused < 0.1)  {
+    unset($memarray);
+    exec("free -m | awk '/Mem:/ { total=$2 } /Mem:/ { used=$3 } END { print used/total*100}'", $memarray);
+    $memused = floor($memarray[0]);
+  }
+
   if     ($memused > 90) { $memused_status = "danger";  }
   elseif ($memused > 75) { $memused_status = "warning"; }
   elseif ($memused >  0) { $memused_status = "success"; }


### PR DESCRIPTION
The "free" command output changed.  It makes the system page show 0% memory usage.  The recommended change retries with a different awk string.

Old output of "Free" command from Raspian Wheezy
$ free -m
             total       used       free     shared    buffers     cached
Mem:           434        278        156          0         79         99
-/+ buffers/cache:         98        336
Swap:           99          0         99

Output from "free" command from Raspian Stretch
$ free -m
              total        used        free      shared  buff/cache   available
Mem:            370          49          84           8         235         262
Swap:            99           1          98