### PR TITLE
Refresh liveview images only when viewing the live view

### DIFF
--- a/includes/liveview.php
+++ b/includes/liveview.php
@@ -12,6 +12,11 @@ function DisplayLiveView(){
   }
 
   ?>
+  <script>
+        setInterval(function () {
+            getImage();
+        }, <?php echo $camera_settings_array["exposure"] ?>);
+  </script>
 
   <div class="row">
 	<p><?php $status->showMessages(); ?></p>

--- a/index.php
+++ b/index.php
@@ -145,10 +145,6 @@ $csrf_token = $_SESSION['csrf_token'];
                 });
         }
 
-        setInterval(function () {
-            getImage();
-        }, <?php echo $camera_settings_array["exposure"] ?>);
-
         // Inititalize theme to light
         if (!localStorage.getItem("theme")) {
             localStorage.setItem("theme", "light")


### PR DESCRIPTION
Currently, the JS function that refreshes the live view images is active on every page of the portal. This results in unnecessary load on the RPI and mobile devices will burn more power downloading, very quickly, image content that will not be used. To fix this, the image data should be refreshed only when the liveview page is in use.