### PR TITLE
Text fixes

### DIFF
--- a/camera_options_ZWO.json
+++ b/camera_options_ZWO.json
@@ -173,7 +173,7 @@
 },
 {
 "name":"extratext",
-"default":"none",
+"default":"",
 "description":"Extra Text File (Requires the full path to the file) If no file ensure this is set to none",
 "label":"Extra Text File",
 "type":"text"

--- a/camera_options_ZWO.json
+++ b/camera_options_ZWO.json
@@ -172,6 +172,27 @@
 "type":"text"
 },
 {
+"name":"extratext",
+"default":"none",
+"description":"Extra Text File (Requires the full path to the file) If no file ensure this is set to none",
+"label":"Extra Text File",
+"type":"text"
+},
+{
+"name":"extratextage",
+"default":"600",
+"description":"The maximum age of the extra text file in seconds. After this time the file will no longer be dispalyed. Set to 0 to always display",
+"label":"Max Age Of Extra",
+"type":"number"
+},
+{
+"name":"textlineheight",
+"default":"30",
+"description":"The line height of the text, if increasing the font size causes the text overlap then increase this value",
+"label":"Line Height",
+"type":"number"
+},
+{
 "name":"textx",
 "default":"15",
 "description":"Text Placement Horizontal from LEFT in Pixels",

--- a/camera_options_ZWO.json
+++ b/camera_options_ZWO.json
@@ -174,7 +174,7 @@
 {
 "name":"extratext",
 "default":"",
-"description":"Extra Text File (Requires the full path to the file) If no file ensure this is set to none",
+"description":"Extra Text File (Requires the full path to the file) If you are not using an extra text file ensure this field is empty",
 "label":"Extra Text File",
 "type":"text"
 },


### PR DESCRIPTION
Adds three new fields to the camera config (To be used in conjunction with the PR on the allsky repo)

- extratext - The full path to a file containing the extra text to be displayed on the images. The file can contain multiple lines, each will be displayed.
- extratextage - If the file above is not updated within this timeframe then the contents of the text file will not be added to the images, handy for when the process updating the text file crashes. To disable this check set the value to 0
- textlineheight - Allows the line height of the text to be changed, saves people manually editing and recompiling capture.cpp