### PR TITLE
Support 5 GHz Wi-Fi which the Pi 4 supports

### DIFF
--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -19,29 +19,29 @@ function DisplayWPAConfig(){
       $network = array('visible' => false, 'configured' => true, 'connected' => false);
     } elseif ($network !== null) {
       if (preg_match('/^\s*}\s*$/', $line)) {
-	$networks[$ssid] = $network;
-	$network = null;
-	$ssid = null;
-      } elseif ($lineArr = preg_split('/\s*=\s*/', trim($line))) {
-	switch(strtolower($lineArr[0])) {
-	  case 'ssid':
-	    $ssid = trim($lineArr[1], '"');
-	    break;
-	  case 'psk':
-	    if (array_key_exists('passphrase', $network)) {
-	      break;
-	    }
-	  case '#psk':
-	    $network['protocol'] = 'WPA';
-	  case 'wep_key0': // Untested
-	    $network['passphrase'] = trim($lineArr[1], '"');
-	    break;
-	  case 'key_mgmt':
-	    if (! array_key_exists('passphrase', $network) && $lineArr[1] === 'NONE') {
-	      $network['protocol'] = 'Open';
-	    }
-	    break;
-	}
+        $networks[$ssid] = $network;
+        $network = null;
+        $ssid = null;
+        } elseif ($lineArr = preg_split('/\s*=\s*/', trim($line))) {
+        switch(strtolower($lineArr[0])) {
+          case 'ssid':
+            $ssid = trim($lineArr[1], '"');
+            break;
+          case 'psk':
+            if (array_key_exists('passphrase', $network)) {
+              break;
+            }
+          case '#psk':
+            $network['protocol'] = 'WPA';
+          case 'wep_key0': // Untested
+            $network['passphrase'] = trim($lineArr[1], '"');
+            break;
+          case 'key_mgmt':
+            if (! array_key_exists('passphrase', $network) && $lineArr[1] === 'NONE') {
+              $network['protocol'] = 'Open';
+            }
+            break;
+        }
       }
     }
   }
@@ -53,56 +53,56 @@ function DisplayWPAConfig(){
       fwrite($wpa_file, 'update_config=1' . PHP_EOL);
 
       foreach(array_keys($_POST) as $post) {
-	if (preg_match('/delete(\d+)/', $post, $post_match)) {
-	  unset($tmp_networks[$_POST['ssid' . $post_match[1]]]);
-	} elseif (preg_match('/update(\d+)/', $post, $post_match)) {
-	  // NB, at the moment, the value of protocol from the form may
-	  // contain HTML line breaks
-	  $tmp_networks[$_POST['ssid' . $post_match[1]]] = array(
-	    'protocol' => ( $_POST['protocol' . $post_match[1]] === 'Open' ? 'Open' : 'WPA' ),
-	    'passphrase' => $_POST['passphrase' . $post_match[1]],
-	    'configured' => true
-	  );
-	}
+        if (preg_match('/delete(\d+)/', $post, $post_match)) {
+          unset($tmp_networks[$_POST['ssid' . $post_match[1]]]);
+        } elseif (preg_match('/update(\d+)/', $post, $post_match)) {
+          // NB, at the moment, the value of protocol from the form may
+          // contain HTML line breaks
+          $tmp_networks[$_POST['ssid' . $post_match[1]]] = array(
+            'protocol' => ( $_POST['protocol' . $post_match[1]] === 'Open' ? 'Open' : 'WPA' ),
+            'passphrase' => $_POST['passphrase' . $post_match[1]],
+            'configured' => true
+          );
+        }
       }
 
       $ok = true;
       foreach($tmp_networks as $ssid => $network) {
-	if ($network['protocol'] === 'Open') {
-	  fwrite($wpa_file, "network={".PHP_EOL);
-	  fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
-	  fwrite($wpa_file, "\tkey_mgmt=NONE".PHP_EOL);
-	  fwrite($wpa_file, "}".PHP_EOL);
-	} else {
-	  if (strlen($network['passphrase']) >=8 && strlen($network['passphrase']) <= 63) {
-	    unset($wpa_passphrase);
-	    unset($line);
-	    exec( 'wpa_passphrase '.escapeshellarg($ssid). ' ' . escapeshellarg($network['passphrase']),$wpa_passphrase );
-	    foreach($wpa_passphrase as $line) {
-	      fwrite($wpa_file, $line.PHP_EOL);
-	    }
-	  } else {
-	    $status->addMessage('WPA passphrase must be between 8 and 63 characters', 'danger');
-	    $ok = false;
+        if ($network['protocol'] === 'Open') {
+          fwrite($wpa_file, "network={".PHP_EOL);
+          fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
+          fwrite($wpa_file, "\tkey_mgmt=NONE".PHP_EOL);
+          fwrite($wpa_file, "}".PHP_EOL);
+        } else {
+          if (strlen($network['passphrase']) >=8 && strlen($network['passphrase']) <= 63) {
+            unset($wpa_passphrase);
+            unset($line);
+            exec( 'wpa_passphrase '.escapeshellarg($ssid). ' ' . escapeshellarg($network['passphrase']),$wpa_passphrase );
+            foreach($wpa_passphrase as $line) {
+              fwrite($wpa_file, $line.PHP_EOL);
+            }
+          } else {
+            $status->addMessage('WPA passphrase must be between 8 and 63 characters', 'danger');
+            $ok = false;
 
-	  }
-	}
+          }
+        }
 
       }
 
       if ($ok) {
-	system( 'sudo cp /tmp/wifidata ' . RASPI_WPA_SUPPLICANT_CONFIG, $returnval );
-	if( $returnval == 0 ) {
-	  exec('sudo wpa_cli reconfigure', $reconfigure_out, $reconfigure_return );
-	  if ($reconfigure_return == 0) {
-	    $status->addMessage('Wifi settings updated successfully', 'success');
-	    $networks = $tmp_networks;
-	  } else {
-	    $status->addMessage('Wifi settings updated but cannot restart (cannon execute "wpa_cli reconfigure")', 'danger');
-	  }
-	} else {
-	  $status->addMessage('Wifi settings failed to be updated', 'danger');
-	}
+        system( 'sudo cp /tmp/wifidata ' . RASPI_WPA_SUPPLICANT_CONFIG, $returnval );
+        if( $returnval == 0 ) {
+          exec('sudo wpa_cli reconfigure', $reconfigure_out, $reconfigure_return );
+          if ($reconfigure_return == 0) {
+            $status->addMessage('Wifi settings updated successfully', 'success');
+            $networks = $tmp_networks;
+          } else {
+            $status->addMessage('Wifi settings updated but cannot restart (cannon execute "wpa_cli reconfigure")', 'danger');
+          }
+        } else {
+          $status->addMessage('Wifi settings failed to be updated', 'danger');
+        }
       }
     } else {
       $status->addMessage('Failed to updated wifi settings', 'danger');
@@ -123,26 +123,26 @@ function DisplayWPAConfig(){
     if (isset($arrNetwork[4])) {
       $ssid = $arrNetwork[4];
       if (array_key_exists($ssid, $networks)) {
-	  $is_new = false;
-	  $networks[$ssid]['visible'] = true;
-	  // Some SSIDs may be on multiple channels in multiple bands
-	  if (! isset($networks[$ssid]['channel'])) {
-		$networks[$ssid]['channel'] = ConvertToChannel($arrNetwork[1]);
-	  } else {
-	      $have_multiple = true;
-		$networks[$ssid]['channel'] = $networks[$ssid]['channel'] . $note;
-	  }
+          $is_new = false;
+          $networks[$ssid]['visible'] = true;
+          // Some SSIDs may be on multiple channels in multiple bands
+          if (! isset($networks[$ssid]['channel'])) {
+                $networks[$ssid]['channel'] = ConvertToChannel($arrNetwork[1]);
+          } else {
+              $have_multiple = true;
+                $networks[$ssid]['channel'] = $networks[$ssid]['channel'] . $note;
+          }
 	  // TODO What if the security has changed?
-	} else {
-	  $networks[$ssid] = array(
-	    'configured' => false,
-	    'protocol' => ConvertToSecurity($arrNetwork[3]),
-	    'channel' => ConvertToChannel($arrNetwork[1]),
-	    'passphrase' => '',
-	    'visible' => true,
-	    'connected' => false
-	  );
-       }
+        } else {
+          $networks[$ssid] = array(
+            'configured' => false,
+            'protocol' => ConvertToSecurity($arrNetwork[3]),
+            'channel' => ConvertToChannel($arrNetwork[1]),
+            'passphrase' => '',
+            'visible' => true,
+            'connected' => false
+          );
+        }
     }
   }
 
@@ -157,10 +157,10 @@ function DisplayWPAConfig(){
   <div class="row">
     <div class="col-lg-12">
       <div class="panel panel-primary">           
-	<div class="panel-heading"><i class="fa fa-signal fa-fw"></i> Configure client</div>
-	<!-- /.panel-heading -->
-	<div class="panel-body">
-	  <p><?php $status->showMessages(); ?></p>
+        <div class="panel-heading"><i class="fa fa-signal fa-fw"></i> Configure client</div>
+        <!-- /.panel-heading -->
+        <div class="panel-body">
+          <p><?php $status->showMessages(); ?></p>
           <h4>Client settings</h4>
 
           <form method="POST" action="?page=wpa_conf" name="wpa_conf_form">
@@ -219,12 +219,12 @@ function DisplayWPAConfig(){
             </table>
           </form>
         </div><!-- ./ Panel body -->
-	<div class="panel-footer">
+        <div class="panel-footer">
           <?php if ($have_multiple)
-	    echo "$note SSID is in multiple channels and/or bands; only the first is listed above.";
+            echo "$note SSID is in multiple channels and/or bands; only the first is listed above.";
             echo "<br>";
           ?>
-	  <strong>Note,</strong> WEP access points appear as 'Open'. The Allsky portal does not currently support connecting to WEP.
+          <strong>Note,</strong> WEP access points appear as 'Open'. The Allsky portal does not currently support connecting to WEP.
         </div>
       </div><!-- /.panel-primary -->
     </div><!-- /.col-lg-12 -->

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -1,166 +1,166 @@
 <?php
 
-	/**
-	*
-	*
-	*/
-	function DisplayWPAConfig(){
-	  $status = new StatusMessages();
-	  $scanned_networks = array();
+/**
+*
+*
+*/
+function DisplayWPAConfig(){
+  $status = new StatusMessages();
+  $scanned_networks = array();
 
-	  // Find currently configured networks
-	  exec(' sudo cat ' . RASPI_WPA_SUPPLICANT_CONFIG, $known_return);
+  // Find currently configured networks
+  exec(' sudo cat ' . RASPI_WPA_SUPPLICANT_CONFIG, $known_return);
 
-	  $network = null;
-	  $ssid = null;
+  $network = null;
+  $ssid = null;
 
-	  foreach($known_return as $line) {
-	    if (preg_match('/network\s*=/', $line)) {
-	      $network = array('visible' => false, 'configured' => true, 'connected' => false);
-	    } elseif ($network !== null) {
-	      if (preg_match('/^\s*}\s*$/', $line)) {
-		$networks[$ssid] = $network;
-		$network = null;
-		$ssid = null;
-	      } elseif ($lineArr = preg_split('/\s*=\s*/', trim($line))) {
-		switch(strtolower($lineArr[0])) {
-		  case 'ssid':
-		    $ssid = trim($lineArr[1], '"');
-		    break;
-		  case 'psk':
-		    if (array_key_exists('passphrase', $network)) {
-		      break;
-		    }
-		  case '#psk':
-		    $network['protocol'] = 'WPA';
-		  case 'wep_key0': // Untested
-		    $network['passphrase'] = trim($lineArr[1], '"');
-		    break;
-		  case 'key_mgmt':
-		    if (! array_key_exists('passphrase', $network) && $lineArr[1] === 'NONE') {
-		      $network['protocol'] = 'Open';
-		    }
-		    break;
-		}
-	      }
+  foreach($known_return as $line) {
+    if (preg_match('/network\s*=/', $line)) {
+      $network = array('visible' => false, 'configured' => true, 'connected' => false);
+    } elseif ($network !== null) {
+      if (preg_match('/^\s*}\s*$/', $line)) {
+	$networks[$ssid] = $network;
+	$network = null;
+	$ssid = null;
+      } elseif ($lineArr = preg_split('/\s*=\s*/', trim($line))) {
+	switch(strtolower($lineArr[0])) {
+	  case 'ssid':
+	    $ssid = trim($lineArr[1], '"');
+	    break;
+	  case 'psk':
+	    if (array_key_exists('passphrase', $network)) {
+	      break;
 	    }
-	  }
-
-	  if ( isset($_POST['client_settings']) && CSRFValidate() ) {
-	    $tmp_networks = $networks;
-	    if ($wpa_file = fopen('/tmp/wifidata', 'w')) {
-	      fwrite($wpa_file, 'ctrl_interface=DIR=' . RASPI_WPA_CTRL_INTERFACE . ' GROUP=netdev' . PHP_EOL);
-	      fwrite($wpa_file, 'update_config=1' . PHP_EOL);
-
-	      foreach(array_keys($_POST) as $post) {
-		if (preg_match('/delete(\d+)/', $post, $post_match)) {
-		  unset($tmp_networks[$_POST['ssid' . $post_match[1]]]);
-		} elseif (preg_match('/update(\d+)/', $post, $post_match)) {
-		  // NB, at the moment, the value of protocol from the form may
-		  // contain HTML line breaks
-		  $tmp_networks[$_POST['ssid' . $post_match[1]]] = array(
-		    'protocol' => ( $_POST['protocol' . $post_match[1]] === 'Open' ? 'Open' : 'WPA' ),
-		    'passphrase' => $_POST['passphrase' . $post_match[1]],
-		    'configured' => true
-		  );
-		}
-	      }
-
-	      $ok = true;
-	      foreach($tmp_networks as $ssid => $network) {
-		if ($network['protocol'] === 'Open') {
-		  fwrite($wpa_file, "network={".PHP_EOL);
-		  fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
-		  fwrite($wpa_file, "\tkey_mgmt=NONE".PHP_EOL);
-		  fwrite($wpa_file, "}".PHP_EOL);
-		} else {
-		  if (strlen($network['passphrase']) >=8 && strlen($network['passphrase']) <= 63) {
-		    unset($wpa_passphrase);
-		    unset($line);
-		    exec( 'wpa_passphrase '.escapeshellarg($ssid). ' ' . escapeshellarg($network['passphrase']),$wpa_passphrase );
-		    foreach($wpa_passphrase as $line) {
-		      fwrite($wpa_file, $line.PHP_EOL);
-		    }
-		  } else {
-		    $status->addMessage('WPA passphrase must be between 8 and 63 characters', 'danger');
-		    $ok = false;
-
-		  }
-		}
-
-	      }
-
-	      if ($ok) {
-		system( 'sudo cp /tmp/wifidata ' . RASPI_WPA_SUPPLICANT_CONFIG, $returnval );
-		if( $returnval == 0 ) {
-		  exec('sudo wpa_cli reconfigure', $reconfigure_out, $reconfigure_return );
-		  if ($reconfigure_return == 0) {
-		    $status->addMessage('Wifi settings updated successfully', 'success');
-		    $networks = $tmp_networks;
-		  } else {
-		    $status->addMessage('Wifi settings updated but cannot restart (cannon execute "wpa_cli reconfigure")', 'danger');
-		  }
-		} else {
-		  $status->addMessage('Wifi settings failed to be updated', 'danger');
-		}
-	      }
-	    } else {
-	      $status->addMessage('Failed to updated wifi settings', 'danger');
+	  case '#psk':
+	    $network['protocol'] = 'WPA';
+	  case 'wep_key0': // Untested
+	    $network['passphrase'] = trim($lineArr[1], '"');
+	    break;
+	  case 'key_mgmt':
+	    if (! array_key_exists('passphrase', $network) && $lineArr[1] === 'NONE') {
+	      $network['protocol'] = 'Open';
 	    }
-	  }
+	    break;
+	}
+      }
+    }
+  }
 
-	  exec( 'sudo wpa_cli scan' );
-	  sleep(3);
-	  exec( 'sudo wpa_cli scan_results',$scan_return );
-	  for( $shift = 0; $shift < 2; $shift++ ) {
-	    array_shift($scan_return);
-	  }
-	  // display output
-	  $have_multiple = false;
-	  $note = " <span style='color: red; font-weight: bold'>*</span>";
-	  foreach( $scan_return as $network ) {
-	    $arrNetwork = preg_split("/[\t]+/",$network);
-	    if (isset($arrNetwork[4])) {
-	      $ssid = $arrNetwork[4];
-	      if (array_key_exists($ssid, $networks)) {
-		  $is_new = false;
-		  $networks[$ssid]['visible'] = true;
-		  // Some SSIDs may be on multiple channels in multiple bands
-		  if (! isset($networks[$ssid]['channel'])) {
-			$networks[$ssid]['channel'] = ConvertToChannel($arrNetwork[1]);
-		  } else {
-		      $have_multiple = true;
-			$networks[$ssid]['channel'] = $networks[$ssid]['channel'] . $note;
-		  }
-		  // TODO What if the security has changed?
-		} else {
-		  $networks[$ssid] = array(
-		    'configured' => false,
-		    'protocol' => ConvertToSecurity($arrNetwork[3]),
-		    'channel' => ConvertToChannel($arrNetwork[1]),
-		    'passphrase' => '',
-		    'visible' => true,
-		    'connected' => false
-		  );
-	       }
+  if ( isset($_POST['client_settings']) && CSRFValidate() ) {
+    $tmp_networks = $networks;
+    if ($wpa_file = fopen('/tmp/wifidata', 'w')) {
+      fwrite($wpa_file, 'ctrl_interface=DIR=' . RASPI_WPA_CTRL_INTERFACE . ' GROUP=netdev' . PHP_EOL);
+      fwrite($wpa_file, 'update_config=1' . PHP_EOL);
+
+      foreach(array_keys($_POST) as $post) {
+	if (preg_match('/delete(\d+)/', $post, $post_match)) {
+	  unset($tmp_networks[$_POST['ssid' . $post_match[1]]]);
+	} elseif (preg_match('/update(\d+)/', $post, $post_match)) {
+	  // NB, at the moment, the value of protocol from the form may
+	  // contain HTML line breaks
+	  $tmp_networks[$_POST['ssid' . $post_match[1]]] = array(
+	    'protocol' => ( $_POST['protocol' . $post_match[1]] === 'Open' ? 'Open' : 'WPA' ),
+	    'passphrase' => $_POST['passphrase' . $post_match[1]],
+	    'configured' => true
+	  );
+	}
+      }
+
+      $ok = true;
+      foreach($tmp_networks as $ssid => $network) {
+	if ($network['protocol'] === 'Open') {
+	  fwrite($wpa_file, "network={".PHP_EOL);
+	  fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
+	  fwrite($wpa_file, "\tkey_mgmt=NONE".PHP_EOL);
+	  fwrite($wpa_file, "}".PHP_EOL);
+	} else {
+	  if (strlen($network['passphrase']) >=8 && strlen($network['passphrase']) <= 63) {
+	    unset($wpa_passphrase);
+	    unset($line);
+	    exec( 'wpa_passphrase '.escapeshellarg($ssid). ' ' . escapeshellarg($network['passphrase']),$wpa_passphrase );
+	    foreach($wpa_passphrase as $line) {
+	      fwrite($wpa_file, $line.PHP_EOL);
 	    }
-	  }
+	  } else {
+	    $status->addMessage('WPA passphrase must be between 8 and 63 characters', 'danger');
+	    $ok = false;
 
-	  exec( 'iwconfig wlan0', $iwconfig_return );
-	  foreach ($iwconfig_return as $line) {
-	    if (preg_match( '/ESSID:\"([^"]+)\"/i',$line,$iwconfig_ssid )) {
-	      $networks[$iwconfig_ssid[1]]['connected'] = true;
-	    }
 	  }
-	?>
+	}
 
-	  <div class="row">
-	    <div class="col-lg-12">
-	      <div class="panel panel-primary">           
-		<div class="panel-heading"><i class="fa fa-signal fa-fw"></i> Configure client</div>
-		<!-- /.panel-heading -->
-		<div class="panel-body">
-		  <p><?php $status->showMessages(); ?></p>
+      }
+
+      if ($ok) {
+	system( 'sudo cp /tmp/wifidata ' . RASPI_WPA_SUPPLICANT_CONFIG, $returnval );
+	if( $returnval == 0 ) {
+	  exec('sudo wpa_cli reconfigure', $reconfigure_out, $reconfigure_return );
+	  if ($reconfigure_return == 0) {
+	    $status->addMessage('Wifi settings updated successfully', 'success');
+	    $networks = $tmp_networks;
+	  } else {
+	    $status->addMessage('Wifi settings updated but cannot restart (cannon execute "wpa_cli reconfigure")', 'danger');
+	  }
+	} else {
+	  $status->addMessage('Wifi settings failed to be updated', 'danger');
+	}
+      }
+    } else {
+      $status->addMessage('Failed to updated wifi settings', 'danger');
+    }
+  }
+
+  exec( 'sudo wpa_cli scan' );
+  sleep(3);
+  exec( 'sudo wpa_cli scan_results',$scan_return );
+  for( $shift = 0; $shift < 2; $shift++ ) {
+    array_shift($scan_return);
+  }
+  // display output
+  $have_multiple = false;
+  $note = " <span style='color: red; font-weight: bold'>*</span>";
+  foreach( $scan_return as $network ) {
+    $arrNetwork = preg_split("/[\t]+/",$network);
+    if (isset($arrNetwork[4])) {
+      $ssid = $arrNetwork[4];
+      if (array_key_exists($ssid, $networks)) {
+	  $is_new = false;
+	  $networks[$ssid]['visible'] = true;
+	  // Some SSIDs may be on multiple channels in multiple bands
+	  if (! isset($networks[$ssid]['channel'])) {
+		$networks[$ssid]['channel'] = ConvertToChannel($arrNetwork[1]);
+	  } else {
+	      $have_multiple = true;
+		$networks[$ssid]['channel'] = $networks[$ssid]['channel'] . $note;
+	  }
+	  // TODO What if the security has changed?
+	} else {
+	  $networks[$ssid] = array(
+	    'configured' => false,
+	    'protocol' => ConvertToSecurity($arrNetwork[3]),
+	    'channel' => ConvertToChannel($arrNetwork[1]),
+	    'passphrase' => '',
+	    'visible' => true,
+	    'connected' => false
+	  );
+       }
+    }
+  }
+
+  exec( 'iwconfig wlan0', $iwconfig_return );
+  foreach ($iwconfig_return as $line) {
+    if (preg_match( '/ESSID:\"([^"]+)\"/i',$line,$iwconfig_ssid )) {
+      $networks[$iwconfig_ssid[1]]['connected'] = true;
+    }
+  }
+?>
+
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="panel panel-primary">           
+	<div class="panel-heading"><i class="fa fa-signal fa-fw"></i> Configure client</div>
+	<!-- /.panel-heading -->
+	<div class="panel-body">
+	  <p><?php $status->showMessages(); ?></p>
           <h4>Client settings</h4>
 
           <form method="POST" action="?page=wpa_conf" name="wpa_conf_form">

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -1,154 +1,166 @@
 <?php
 
-/**
-*
-*
-*/
-function DisplayWPAConfig(){
-  $status = new StatusMessages();
-  $scanned_networks = array();
+	/**
+	*
+	*
+	*/
+	function DisplayWPAConfig(){
+	  $status = new StatusMessages();
+	  $scanned_networks = array();
 
-  // Find currently configured networks
-  exec(' sudo cat ' . RASPI_WPA_SUPPLICANT_CONFIG, $known_return);
+	  // Find currently configured networks
+	  exec(' sudo cat ' . RASPI_WPA_SUPPLICANT_CONFIG, $known_return);
 
-  $network = null;
-  $ssid = null;
+	  $network = null;
+	  $ssid = null;
 
-  foreach($known_return as $line) {
-    if (preg_match('/network\s*=/', $line)) {
-      $network = array('visible' => false, 'configured' => true, 'connected' => false);
-    } elseif ($network !== null) {
-      if (preg_match('/^\s*}\s*$/', $line)) {
-        $networks[$ssid] = $network;
-        $network = null;
-        $ssid = null;
-      } elseif ($lineArr = preg_split('/\s*=\s*/', trim($line))) {
-        switch(strtolower($lineArr[0])) {
-          case 'ssid':
-            $ssid = trim($lineArr[1], '"');
-            break;
-          case 'psk':
-            if (array_key_exists('passphrase', $network)) {
-              break;
-            }
-          case '#psk':
-            $network['protocol'] = 'WPA';
-          case 'wep_key0': // Untested
-            $network['passphrase'] = trim($lineArr[1], '"');
-            break;
-          case 'key_mgmt':
-            if (! array_key_exists('passphrase', $network) && $lineArr[1] === 'NONE') {
-              $network['protocol'] = 'Open';
-            }
-            break;
-        }
-      }
-    }
-  }
+	  foreach($known_return as $line) {
+	    if (preg_match('/network\s*=/', $line)) {
+	      $network = array('visible' => false, 'configured' => true, 'connected' => false);
+	    } elseif ($network !== null) {
+	      if (preg_match('/^\s*}\s*$/', $line)) {
+		$networks[$ssid] = $network;
+		$network = null;
+		$ssid = null;
+	      } elseif ($lineArr = preg_split('/\s*=\s*/', trim($line))) {
+		switch(strtolower($lineArr[0])) {
+		  case 'ssid':
+		    $ssid = trim($lineArr[1], '"');
+		    break;
+		  case 'psk':
+		    if (array_key_exists('passphrase', $network)) {
+		      break;
+		    }
+		  case '#psk':
+		    $network['protocol'] = 'WPA';
+		  case 'wep_key0': // Untested
+		    $network['passphrase'] = trim($lineArr[1], '"');
+		    break;
+		  case 'key_mgmt':
+		    if (! array_key_exists('passphrase', $network) && $lineArr[1] === 'NONE') {
+		      $network['protocol'] = 'Open';
+		    }
+		    break;
+		}
+	      }
+	    }
+	  }
 
-  if ( isset($_POST['client_settings']) && CSRFValidate() ) {
-    $tmp_networks = $networks;
-    if ($wpa_file = fopen('/tmp/wifidata', 'w')) {
-      fwrite($wpa_file, 'ctrl_interface=DIR=' . RASPI_WPA_CTRL_INTERFACE . ' GROUP=netdev' . PHP_EOL);
-      fwrite($wpa_file, 'update_config=1' . PHP_EOL);
+	  if ( isset($_POST['client_settings']) && CSRFValidate() ) {
+	    $tmp_networks = $networks;
+	    if ($wpa_file = fopen('/tmp/wifidata', 'w')) {
+	      fwrite($wpa_file, 'ctrl_interface=DIR=' . RASPI_WPA_CTRL_INTERFACE . ' GROUP=netdev' . PHP_EOL);
+	      fwrite($wpa_file, 'update_config=1' . PHP_EOL);
 
-      foreach(array_keys($_POST) as $post) {
-        if (preg_match('/delete(\d+)/', $post, $post_match)) {
-          unset($tmp_networks[$_POST['ssid' . $post_match[1]]]);
-        } elseif (preg_match('/update(\d+)/', $post, $post_match)) {
-          // NB, at the moment, the value of protocol from the form may
-          // contain HTML line breaks
-          $tmp_networks[$_POST['ssid' . $post_match[1]]] = array(
-            'protocol' => ( $_POST['protocol' . $post_match[1]] === 'Open' ? 'Open' : 'WPA' ),
-            'passphrase' => $_POST['passphrase' . $post_match[1]],
-            'configured' => true
-          );
-        }
-      }
+	      foreach(array_keys($_POST) as $post) {
+		if (preg_match('/delete(\d+)/', $post, $post_match)) {
+		  unset($tmp_networks[$_POST['ssid' . $post_match[1]]]);
+		} elseif (preg_match('/update(\d+)/', $post, $post_match)) {
+		  // NB, at the moment, the value of protocol from the form may
+		  // contain HTML line breaks
+		  $tmp_networks[$_POST['ssid' . $post_match[1]]] = array(
+		    'protocol' => ( $_POST['protocol' . $post_match[1]] === 'Open' ? 'Open' : 'WPA' ),
+		    'passphrase' => $_POST['passphrase' . $post_match[1]],
+		    'configured' => true
+		  );
+		}
+	      }
 
-      $ok = true;
-      foreach($tmp_networks as $ssid => $network) {
-        if ($network['protocol'] === 'Open') {
-          fwrite($wpa_file, "network={".PHP_EOL);
-          fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
-          fwrite($wpa_file, "\tkey_mgmt=NONE".PHP_EOL);
-          fwrite($wpa_file, "}".PHP_EOL);
-        } else {
-          if (strlen($network['passphrase']) >=8 && strlen($network['passphrase']) <= 63) {
-	    unset($wpa_passphrase);
-            unset($line);
-	    exec( 'wpa_passphrase '.escapeshellarg($ssid). ' ' . escapeshellarg($network['passphrase']),$wpa_passphrase );
-            foreach($wpa_passphrase as $line) {
-              fwrite($wpa_file, $line.PHP_EOL);
-            }
-          } else {
-            $status->addMessage('WPA passphrase must be between 8 and 63 characters', 'danger');
-            $ok = false;
+	      $ok = true;
+	      foreach($tmp_networks as $ssid => $network) {
+		if ($network['protocol'] === 'Open') {
+		  fwrite($wpa_file, "network={".PHP_EOL);
+		  fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
+		  fwrite($wpa_file, "\tkey_mgmt=NONE".PHP_EOL);
+		  fwrite($wpa_file, "}".PHP_EOL);
+		} else {
+		  if (strlen($network['passphrase']) >=8 && strlen($network['passphrase']) <= 63) {
+		    unset($wpa_passphrase);
+		    unset($line);
+		    exec( 'wpa_passphrase '.escapeshellarg($ssid). ' ' . escapeshellarg($network['passphrase']),$wpa_passphrase );
+		    foreach($wpa_passphrase as $line) {
+		      fwrite($wpa_file, $line.PHP_EOL);
+		    }
+		  } else {
+		    $status->addMessage('WPA passphrase must be between 8 and 63 characters', 'danger');
+		    $ok = false;
 
-          }
-        }
+		  }
+		}
 
-      }
+	      }
 
-      if ($ok) {
-        system( 'sudo cp /tmp/wifidata ' . RASPI_WPA_SUPPLICANT_CONFIG, $returnval );
-        if( $returnval == 0 ) {
-          exec('sudo wpa_cli reconfigure', $reconfigure_out, $reconfigure_return );
-          if ($reconfigure_return == 0) {
-            $status->addMessage('Wifi settings updated successfully', 'success');
-            $networks = $tmp_networks;
-          } else {
-            $status->addMessage('Wifi settings updated but cannot restart (cannon execute "wpa_cli reconfigure")', 'danger');
-          }
-        } else {
-          $status->addMessage('Wifi settings failed to be updated', 'danger');
-        }
-      }
-    } else {
-      $status->addMessage('Failed to updated wifi settings', 'danger');
-    }
-  }
+	      if ($ok) {
+		system( 'sudo cp /tmp/wifidata ' . RASPI_WPA_SUPPLICANT_CONFIG, $returnval );
+		if( $returnval == 0 ) {
+		  exec('sudo wpa_cli reconfigure', $reconfigure_out, $reconfigure_return );
+		  if ($reconfigure_return == 0) {
+		    $status->addMessage('Wifi settings updated successfully', 'success');
+		    $networks = $tmp_networks;
+		  } else {
+		    $status->addMessage('Wifi settings updated but cannot restart (cannon execute "wpa_cli reconfigure")', 'danger');
+		  }
+		} else {
+		  $status->addMessage('Wifi settings failed to be updated', 'danger');
+		}
+	      }
+	    } else {
+	      $status->addMessage('Failed to updated wifi settings', 'danger');
+	    }
+	  }
 
-  exec( 'sudo wpa_cli scan' );
-  sleep(3);
-  exec( 'sudo wpa_cli scan_results',$scan_return );
-  for( $shift = 0; $shift < 2; $shift++ ) {
-    array_shift($scan_return);
-  }
-  // display output
-  foreach( $scan_return as $network ) {
-    $arrNetwork = preg_split("/[\t]+/",$network);
-    if (array_key_exists($arrNetwork[4], $networks)) {
-      $networks[$arrNetwork[4]]['visible'] = true;
-      $networks[$arrNetwork[4]]['channel'] = ConvertToChannel($arrNetwork[1]);
-      // TODO What if the security has changed?
-    } else {
-      $networks[$arrNetwork[4]] = array(
-        'configured' => false,
-        'protocol' => ConvertToSecurity($arrNetwork[3]),
-        'channel' => ConvertToChannel($arrNetwork[1]),
-        'passphrase' => '',
-        'visible' => true,
-        'connected' => false
-      );
-    }
-  }
+	  exec( 'sudo wpa_cli scan' );
+	  sleep(3);
+	  exec( 'sudo wpa_cli scan_results',$scan_return );
+	  for( $shift = 0; $shift < 2; $shift++ ) {
+	    array_shift($scan_return);
+	  }
+	  // display output
+	  $have_multiple = false;
+	  $note = " <span style='color: red; font-weight: bold'>*</span>";
+	  foreach( $scan_return as $network ) {
+	    $arrNetwork = preg_split("/[\t]+/",$network);
+	    if (isset($arrNetwork[4])) {
+	      $ssid = $arrNetwork[4];
+	      if (array_key_exists($ssid, $networks)) {
+		  $is_new = false;
+		  $networks[$ssid]['visible'] = true;
+		  // Some SSIDs may be on multiple channels in multiple bands
+		  if (! isset($networks[$ssid]['channel'])) {
+			$networks[$ssid]['channel'] = ConvertToChannel($arrNetwork[1]);
+		  } else {
+		      $have_multiple = true;
+			$networks[$ssid]['channel'] = $networks[$ssid]['channel'] . $note;
+		  }
+		  // TODO What if the security has changed?
+		} else {
+		  $networks[$ssid] = array(
+		    'configured' => false,
+		    'protocol' => ConvertToSecurity($arrNetwork[3]),
+		    'channel' => ConvertToChannel($arrNetwork[1]),
+		    'passphrase' => '',
+		    'visible' => true,
+		    'connected' => false
+		  );
+	       }
+	    }
+	  }
 
-  exec( 'iwconfig wlan0', $iwconfig_return );
-  foreach ($iwconfig_return as $line) {
-    if (preg_match( '/ESSID:\"([^"]+)\"/i',$line,$iwconfig_ssid )) {
-      $networks[$iwconfig_ssid[1]]['connected'] = true;
-    }
-  }
-?>
+	  exec( 'iwconfig wlan0', $iwconfig_return );
+	  foreach ($iwconfig_return as $line) {
+	    if (preg_match( '/ESSID:\"([^"]+)\"/i',$line,$iwconfig_ssid )) {
+	      $networks[$iwconfig_ssid[1]]['connected'] = true;
+	    }
+	  }
+	?>
 
-  <div class="row">
-    <div class="col-lg-12">
-      <div class="panel panel-primary">           
-        <div class="panel-heading"><i class="fa fa-signal fa-fw"></i> Configure client</div>
-        <!-- /.panel-heading -->
-        <div class="panel-body">
-          <p><?php $status->showMessages(); ?></p>
+	  <div class="row">
+	    <div class="col-lg-12">
+	      <div class="panel panel-primary">           
+		<div class="panel-heading"><i class="fa fa-signal fa-fw"></i> Configure client</div>
+		<!-- /.panel-heading -->
+		<div class="panel-body">
+		  <p><?php $status->showMessages(); ?></p>
           <h4>Client settings</h4>
 
           <form method="POST" action="?page=wpa_conf" name="wpa_conf_form">
@@ -158,7 +170,7 @@ function DisplayWPAConfig(){
               <tr>
                 <th></th>
                 <th>SSID</th>
-                <th>Channel</th>
+                <th>Channel&nbsp;/&nbsp;Band</th>
                 <th>Security</th>
                 <th>Passphrase</th>
                 <th></th>
@@ -167,22 +179,24 @@ function DisplayWPAConfig(){
             <?php foreach ($networks as $ssid => $network) { ?>
               <tr>
                 <td>
-                <?php if ($network['configured']) { ?>
-                <i class="fa fa-check-circle fa-fw"></i>
-                <?php } ?>
-                <?php if ($network['connected']) { ?>
-                <i class="fa fa-exchange-alt fa-fw"></i>
-                <?php } ?>
+                  <?php if ($network['configured']) { ?>
+                  <i class="fa fa-check-circle fa-fw" title="configured"></i>
+                  <?php } ?>
+                  <?php if ($network['connected']) { ?>
+                  <i class="fa fa-exchange-alt fa-fw" title="connected"></i>
+                  <?php } ?>
                 </td>
                 <td>
                   <input type="hidden" name="ssid<?php echo $index ?>" value="<?php echo htmlentities($ssid) ?>" />
                   <?php echo $ssid ?>
                 </td>
+                <td>
               <?php if ($network['visible']) { ?>
-                <td><?php echo $network['channel'] ?></td>
+                <?php echo $network['channel'] ?>
               <?php } else { ?>
-                <td><span class="label label-warning">X</span></td>
+                <span class="label label-warning">X</span>
               <?php } ?>
+                </td>
                 <td><input type="hidden" name="protocol<?php echo $index ?>" value="<?php echo $network['protocol'] ?>" /><?php echo $network['protocol'] ?></td>
               <?php if ($network['protocol'] === 'Open') { ?>
                 <td><input type="hidden" name="passphrase<?php echo $index ?>" value="" />---</td>
@@ -205,11 +219,16 @@ function DisplayWPAConfig(){
             </table>
           </form>
         </div><!-- ./ Panel body -->
-        <div class="panel-footer"><strong>Note,</strong> WEP access points appear as 'Open'. The Allsky portal does not currently support connecting to WEP.</div>
+	<div class="panel-footer">
+          <?php if ($have_multiple)
+	    echo "$note SSID is in multiple channels and/or bands; only the first is listed above.";
+            echo "<br>";
+          ?>
+	  <strong>Note,</strong> WEP access points appear as 'Open'. The Allsky portal does not currently support connecting to WEP.
+        </div>
       </div><!-- /.panel-primary -->
     </div><!-- /.col-lg-12 -->
   </div><!-- /.row -->
 <?php
 }
-
 ?>

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -22,7 +22,7 @@ function DisplayWPAConfig(){
         $networks[$ssid] = $network;
         $network = null;
         $ssid = null;
-        } elseif ($lineArr = preg_split('/\s*=\s*/', trim($line))) {
+      } elseif ($lineArr = preg_split('/\s*=\s*/', trim($line))) {
         switch(strtolower($lineArr[0])) {
           case 'ssid':
             $ssid = trim($lineArr[1], '"');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -90,11 +90,17 @@ function ParseConfig( $arrConfig ) {
 * @return $channel
 */
 function ConvertToChannel( $freq ) {
-  $channel = ($freq - 2407)/5;
-  if ($channel > 0 && $channel < 14) {
-    return $channel;
-  } else {
-    return 'Invalid Channel';
+  $channel = ($freq - 2407)/5;	// check for 2.4 GHz
+  if ($channel > 0 && $channel <= 14) {
+    return $channel . " / 2.4GHz";
+  } else {	// check for 5 GHz
+    $channel = ($freq - 5030)/5;
+    if ($channel >= 7 && $channel <= 165) {
+      // There are also some channels in the 4915 - 4980 range...
+      return $channel . " / 5GHz";
+    } else {
+      return 'Invalid&nbsp;Channel, Hz=' . $freq;
+    }
   }
 }
 
@@ -560,7 +566,6 @@ function ListFileType($dir, $imageFileName, $formalImageTypeName, $type) {	// if
 			}
 		}
 	        echo "</div>";
-
 	}
 }
 


### PR DESCRIPTION
Not sure why there are lots of space-versus-tab changes since I didn't change that.  Perhaps Geany or the Pi text editor converts tabs to spaces or spaces to tabs?
Anyhow, ignoring those changes, configure_client.php checks for SSIDs on multiple channels and/or in multiple bands, and displays the first one.  Subsequent ones have a red "*" displayed next to the SSID to indicate the SSID is duplicated, and a note appears at the bottom of the page.  Also, the band (2.4 GHz or 5 GHz) is displayed next to the channel.

Please check the logic of the 5 GHz frequency-to-channel conversion in functions.php.  I used the same logic as Thomas did for 2.4 GHz.