### PR TITLE
don't display full contents of ALLSKY_SCRIPTS

### DIFF
--- a/includes/editor.php
+++ b/includes/editor.php
@@ -60,20 +60,19 @@ function DisplayEditor()
                     <p><?php $status->showMessages(); ?></p>
                         <div id="editorContainer"></div>
                         <div style="margin-top: 15px;">
-			    <?php
-                    $scripts = array_filter(array_diff(scandir(ALLSKY_SCRIPTS), array('.', '..')), function($item) {
-						if ($showFullList == "true")
-							return !is_dir(ALLSKY_SCRIPTS.$item);
-						else
-							return $item == "endOfNight_additionalSteps.sh";
-					});
+                            <?php
+						if(isset($showFullList) && $showFullList == "true") {
+							$scripts = array_filter(array_diff(scandir(ALLSKY_SCRIPTS), array('.', '..')), function($item) {
+								return !is_dir(ALLSKY_SCRIPTS.$item);
+							});
+						} else
+							$scripts[0] = "endOfNight_additionalSteps.sh";
 			    ?>
                             <select class="form-control" id="script_path"
                                     style="display: inline-block; width: auto; margin-right: 15px; margin-bottom: 5px"
                                     >
                                 <option value="current<?php echo ALLSKY_CONFIG_DIR ?>/config.sh">config.sh</option>
                                 <option value="current<?php echo ALLSKY_CONFIG_DIR ?>/ftp-settings.sh">ftp-settings.sh</option>
-                                <option value="current/allsky.sh">allsky.sh</option>
 
 				<?php
 							foreach ($scripts as $script) {


### PR DESCRIPTION
Per discussion with Thomas, we should be discouraging users to edit the scripts, except for endOfNight_additionalSteps.sh which is designed to be user-editable.
This change only displays that file from ALLSKY_SCRIPTS, in addition to the configuration files the user needs to edit.