### PR TITLE
safer date filter

### DIFF
--- a/includes/days.php
+++ b/includes/days.php
@@ -19,7 +19,7 @@ if (isset($_POST['delete_directory'])) {
 
 if ($handle = opendir(ALLSKY_IMAGES)) {
     while (false !== ($day = readdir($handle))) {
-        if (preg_match('/^2\d{7}$/', $day)) {
+        if (preg_match('/^(2\d{7}|test\w+)$/', $day)) {
             $days[] = $day;
         }
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -490,7 +490,7 @@ function ListFileType($dir, $imageFileName, $formalImageTypeName, $type) {	// if
 	if ($chosen_day === 'All'){
 		if ($handle = opendir(ALLSKY_IMAGES)) {
 		    while (false !== ($day = readdir($handle))) {
-		        if (preg_match('/^2\d{7}$/', $day)) {
+		        if (preg_match('/^(2\d{7}|test\w+)$/', $day)) {
 		            $days[] = $day;
 			    $num += 1;
 		        }


### PR DESCRIPTION
Instead of filtering out a few potentially bad directory names, only include acceptable names.

A regex match for 8 digits where the first one is '2' comes pretty close. Sure, it would permit the 42nd day of the 13th month of 2999 (29991342), but that's better than listing random stuff in the images directory.