### PR TITLE
more image filtering

### DIFF
--- a/includes/days.php
+++ b/includes/days.php
@@ -19,7 +19,7 @@ if (isset($_POST['delete_directory'])) {
 
 if ($handle = opendir(ALLSKY_IMAGES)) {
     while (false !== ($day = readdir($handle))) {
-        if (preg_match('/^(2\d{7}|test\w+)$/', $day)) {
+        if (preg_match('/^(2\d{7}|test\w*)$/', $day)) {
             $days[] = $day;
         }
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -490,7 +490,7 @@ function ListFileType($dir, $imageFileName, $formalImageTypeName, $type) {	// if
 	if ($chosen_day === 'All'){
 		if ($handle = opendir(ALLSKY_IMAGES)) {
 		    while (false !== ($day = readdir($handle))) {
-		        if (preg_match('/^(2\d{7}|test\w+)$/', $day)) {
+		        if (preg_match('/^(2\d{7}|test\w*)$/', $day)) {
 		            $days[] = $day;
 			    $num += 1;
 		        }

--- a/includes/images.php
+++ b/includes/images.php
@@ -8,10 +8,9 @@ $num = 0;	// Keep track of count so we can tell user when no files exist.
 
 
 if ($handle = opendir(ALLSKY_IMAGES . '/'.$chosen_day)) {
-    $blacklist = array('.', '..', '*.mp4', 'startrails', 'keogram', 'thumbnails');
     while (false !== ($image = readdir($handle))) {
 	$ext = explode(".",$image);
-        if (!in_array($image, $blacklist) && $ext[1]!='mp4') {
+        if (preg_match('/^\w+-\d{14}[.](jpe?g|png)$/i', $image)){
             $images[] = $image;
 	    $num += 1;
         }


### PR DESCRIPTION
instead of trying to enumerate and reject all possible bad filenames,
define a pattern that describes good filenames and display matches.

change test to `test\w*` so that `test` would be allowed too.