### PR TITLE
images.php: navbar limit of 50

### DIFF
--- a/includes/images.php
+++ b/includes/images.php
@@ -5,12 +5,14 @@ function ListImages(){
 $images = array();
 $chosen_day = $_GET['day'];
 $num = 0;	// Keep track of count so we can tell user when no files exist.
+$nav_images_max = 50;	// hide the navigation bar if more than this number of images are displayed.
 
 
 if ($handle = opendir(ALLSKY_IMAGES . '/'.$chosen_day)) {
+    $blacklist = array('.', '..', '*.mp4', 'startrails', 'keogram', 'thumbnails');
     while (false !== ($image = readdir($handle))) {
 	$ext = explode(".",$image);
-        if (preg_match('/^\w+-\d{14}[.](jpe?g|png)$/i', $image)){
+        if (!in_array($image, $blacklist) && $ext[1]!='mp4') {
             $images[] = $image;
 	    $num += 1;
         }
@@ -28,14 +30,15 @@ if ($num > 0) asort($images);
 
 <script>
 $( document ).ready(function() {
-        $('#images').viewer({
+	$('#images').viewer({
 		url(image) {
-                	return image.src.replace('/thumbnails', '/');
-        	},
+			return image.src.replace('/thumbnails', '/');
+		},
+		<?php if ($num > $nav_images_max) echo "navbar: 0,"; // if there are a lot of images it takes forever to display the navbar. ?>
 		transition: false
 	});
-        $('.thumb').each(function(){		
-			this.title=getTimeStamp(this.src);
+	$('.thumb').each(function(){		
+		this.title=getTimeStamp(this.src);
 	});
 });
 


### PR DESCRIPTION
Fixes Project "allsky-portal loads too many thumbnails when viewing image".
When viewing images in the WebUI there are typically hundreds or thousands per day.  When clicking on an image it brings up a larger version and put a navigation bar at the bottom with tiny versions of ALL the images.  This takes forever when there are thousands of images.  My solution is to disable the navigation bar when > 50 images are displayed (50 are displayed quickly on a Pi 4.