### PR TITLE
functions.php: move warning message

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -536,9 +536,9 @@ function ListFileType($dir, $imageFileName, $formalImageTypeName, $type) {	// if
 						}
 			  		}
 				}
-				if ($num == 0) {
-					echo "<span class='alert-warning'>There are no $formalImageTypeName.</span>";
-				}
+			}
+			if ($num == 0) {
+				echo "<span class='alert-warning'>There are no $formalImageTypeName.</span>";
 			}
 		}
 	} else {


### PR DESCRIPTION
The warning message incorrectly was displayed for every day that didn't have a timelapse, keogram, or startrails.  It should have only been displayed if NONE of the days had the files.