### PR TITLE
raspap.php: use RASPI_ADMIN_DETAILS

### DIFF
--- a/raspap.php
+++ b/raspap.php
@@ -1,12 +1,14 @@
 <?php
 
+// Default admin username and password:
 $config = array(
   'admin_user' => 'admin',
   'admin_pass' => '$2y$10$YKIyWAmnQLtiJAy6QgHQ.eCpY4m.HCEbiHaTgN6.acNC6bDElzt.i'
 );
 
-if(file_exists(RASPI_CONFIG.'/raspap.auth')) {
-    if ( $auth_details = fopen(RASPI_CONFIG.'/raspap.auth', 'r') ) {
+// Can be overridden by what's in this file, if it exists:
+if(file_exists(RASPI_ADMIN_DETAILS)) {
+    if ( $auth_details = fopen(RASPI_ADMIN_DETAILS, 'r') ) {
       $config['admin_user'] = trim(fgets($auth_details));
       $config['admin_pass'] = trim(fgets($auth_details));
       fclose($auth_details);


### PR DESCRIPTION
Use "RASPI_ADMIN_DETAILS" instead of "RASPI_CONFIG . 'raspap.auth'" to make it easier to update the name of raspap.auth in the future (which we may want to do with the unified configuration file.
Also added a couple comments.