### PR TITLE
camera_options_RPiHQ.json: added entries

### DIFF
--- a/camera_options_RPiHQ.json
+++ b/camera_options_RPiHQ.json
@@ -2,54 +2,162 @@
 {
 "name":"",
 "default":"",
-"description":"Exposure settings",
+"description":"Daytime settings",
 "label":"",
 "type":"header",
 "advanced":0
 },
 {
-"name":"nightexposure",
-"default":"60000",
-"description":"Time in ms (1000ms = 1 sec, range 1 - 240000 ms)",
+"name":"dayautoexposure",
+"default":1,
+"description":"Activate to enable daytime auto-exposure.",
+"label":"Auto-Exposure",
+"type":"checkbox",
+"advanced":1
+},
+{
+"name":"dayexposure",
+"default":32,
+"description":"Time in ms (1000ms = 1 sec, range 1 - 200000 ms)",
 "label":"Exposure",
 "type":"number",
-"advanced":0
+"advanced":1
 },
 {
-"name":"nightgain",
-"default":"4",
-"description":"Light sensitivity. Starts at 1 till 16. A high value returns a brighter image but more noise too",
-"label":"Gain",
-"type":"number",
-"advanced":0
-},
-{
-"name":"nightautogain",
-"default":"0",
-"description":"Activate to enable auto-gain",
-"label":"Auto-Gain",
-"type":"checkbox",
-"advanced":0
-},
-{
-"name":"gamma",
-"default":"50",
-"description":"-100 to 100. Changes the difference between light and dark areas. A hight value increases contrast",
-"label":"Gamma",
-"type":"number",
-"advanced":0
-},
-{
-"name":"brightness",
-"default":"50",
+"name":"daybrightness",
+"default":50,
 "description":"0 to 100. Changes the amount of light in the image. Low value = dark. high value = bright",
 "label":"Brightness",
 "type":"number",
 "advanced":0
 },
 {
+"name":"daydelay",
+"default":15000,
+"description":"Delay between images during daytime in milliseconds. 1000ms = 1 sec.",
+"label":"Delay",
+"type":"number",
+"advanced":0
+},
+{
+"name":"dayautogain",
+"default":1,
+"description":"Activate to enable dayime auto-gain.",
+"label":"Auto-Gain",
+"type":"checkbox",
+"advanced":1
+},
+{
+"name":"daygain",
+"default":1.0,
+"description":"Manually set the gain (light sensitivity).<br>Starts at 1.0. A high value returns a brighter image but more noise too.",
+"label":"Gain",
+"type":"number",
+"advanced":1
+},
+{
+"name":"daybin",
+"default":1,
+"description":"1 = binning OFF (1x1), 2x2 binning, 4 = 4x4 binning",
+"label":"Binning",
+"type":"select",
+"options": [
+	{"value": "1", "label": "1x1 binning"},
+	{"value": "2", "label": "2x2 binning"},
+	{"value": "4", "label": "4x4 binning"}
+],
+"advanced":1
+},
+
+{
+"name":"",
+"default":"",
+"description":"Nighttime settings",
+"label":"",
+"type":"header",
+"advanced":0
+},
+{
+"name":"nightautoexposure",
+"default":1,
+"description":"Activate to enable nighttime auto-exposure.",
+"label":"Auto-Exposure",
+"type":"checkbox",
+"advanced":0
+},
+{
+"name":"nightexposure",
+"default":20000,
+"description":"Time in ms (1000ms = 1 sec, range 1 - 200000 ms)",
+"label":"Exposure",
+"type":"number",
+"advanced":0
+},
+{
+"name":"nightbrightness",
+"default":50,
+"description":"0 to 100. Changes the amount of light in the image. Low value = dark. high value = bright",
+"label":"Brightness",
+"type":"number",
+"advanced":0
+},
+{
+"name":"nightdelay",
+"default":10,
+"description":"Delay between images in milliseconds. 1000ms = 1 sec.",
+"label":"Delay",
+"type":"number",
+"advanced":0
+},
+{
+"name":"nightautogain",
+"default":1,
+"description":"Activate to enable nighttime auto-gain",
+"label":"Auto-Gain",
+"type":"checkbox",
+"advanced":0
+},
+{
+"name":"nightgain",
+"default":1.0,
+"description":"Light sensitivity. Range: 1 to 16. A high value returns a brighter image but more noise too",
+"label":"Gain",
+"type":"number",
+"advanced":0
+},
+{
+"name":"nightbin",
+"default":1,
+"description":"1 = binning OFF (1x1), 2x2 binning, 4 = 4x4 binning",
+"label":"Binning",
+"type":"select",
+"options": [
+	{"value": "1", "label": "1x1 binning"},
+	{"value": "2", "label": "2x2 binning"},
+	{"value": "4", "label": "4x4 binning"}
+],
+"advanced":0
+},
+
+{
+"name":"",
+"default":"",
+"description":"Both daytime and nightime settings",
+"label":"",
+"type":"header",
+"advanced":0
+},
+{
+"name":"saturation",
+"default":50,
+"description":"-100 to 100 on Buster, 0.0 to 2.0 on Bullseye.",
+"label":"Saturation",
+"type":"text",
+"advanced":0
+},
+{
 "name":"awb",
-"default":"0",
+"default":0,
 "description":"Auto White Balance",
 "label":"AWB",
 "type":"checkbox",
@@ -57,60 +165,31 @@
 },
 {
 "name":"wbr",
-"default":"2.5",
-"description":"Red component for the White Balance, range 0 - 10",
+"default":2.5,
+"description":"Red component for the White Balance, range 0.0 - 10.0",
 "label":"Red balance",
 "type":"text",
 "advanced":0
 },
 {
 "name":"wbb",
-"default":"2",
-"description":"Blue component for the White Balance, range 0 - 10",
+"default":2.0,
+"description":"Blue component for the White Balance, range 0.0 - 10.0",
 "label":"Blue balance",
 "type":"text",
 "advanced":0
 },
 {
-"name":"nightbin",
-"default":"1",
-"description":"1 = binning OFF (1x1), 2x2 binning, 4 = 4x4 binning",
-"label":"Binning",
-"type":"select",
-"options": [
-		{"value": "1", "label": "1x1 binning"},
-		{"value": "2", "label": "2x2 binning"},
-		{"value": "4", "label": "4x4 binning"}
-],
-"advanced":0
-},
-{
-"name":"nightdelay",
-"default":"10",
-"description":"Delay between images in milliseconds. 1000ms = 1 sec.",
-"label":"Delay",
-"type":"number",
-"advanced":0
-},
-{
-"name":"daydelay",
-"default":"15000",
-"description":"Delay between images during daytime in milliseconds. 1000ms = 1 sec.",
-"label":"Daytime Delay",
-"type":"number",
-"advanced":0
-},
-{
 "name":"quality",
-"default":"95",
-"description":"Quality range for a JPG image, range 0% - 100%",
+"default":95,
+"description":"Range for a PNG image: 0-9. Range for a JPG image: 0-100.<br>Higher numbers produce larger, clearer files.",
 "label":"Quality",
 "type":"number",
 "advanced":0
 },
 {
 "name":"width",
-"default":"0",
+"default":0,
 "description":"Image width. 0 = max width",
 "label":"Width",
 "type":"number",
@@ -118,37 +197,52 @@
 },
 {
 "name":"height",
-"default":"0",
+"default":0,
 "description":"Image height. 0 = max height",
 "label":"Height",
 "type":"number",
 "advanced":0
 },
 {
+"name":"type",
+"default":99,
+"description":"Choose between auto, color (RGB24) or grayscale (RAW8 or RAW16 for mono cameras, Y8 for color cameras).<br>16 bits only works with PNG extension. 'auto' is same as RGB24.",
+"label":"Image Type",
+"type":"select",
+"options": [
+	{"value": 99, "label": "auto"},
+	{"value": 0, "label": "RAW8"},
+	{"value": 1, "label": "RGB24"},
+	{"value": 2, "label": "RAW16"},
+	{"value": 3, "label": "Y8"}
+],
+"advanced":1
+},
+{
 "name":"filename",
 "default":"image.jpg",
-"description":"No whitespaces in filename. Extensions allowed: .jpg",
+"description":"Extensions allowed: .jpg",
 "label":"Filename",
 "type":"text",
 "advanced":0
 },
 {
 "name":"rotation",
-"defualt":"0",
+"defualt":0,
 "description":"Set image rotation to enable proper orientation, range 0 - 359 degrees",
 "label":"Orientation",
 "type":"select",
 "options": [
-		{"value": "0", "label": "No rotation"},
-		{"value": "90", "label": "90 degrees"},
-		{"value": "180", "label": "180 degrees"},
-		{"value": "270", "label": "270 degrees"}
+	{"value": "0", "label": "No rotation"},
+	{"value": "90", "label": "90 degrees"},
+	{"value": "180", "label": "180 degrees"},
+	{"value": "270", "label": "270 degrees"}
 ],
 "advanced":0
 },
 {
 "name":"flip",
-"default":"0",
+"default":0,
 "description":"Select a flipping option if you want to reverse the image along an axis",
 "label":"Flip",
 "type":"select",
@@ -170,26 +264,161 @@
 "advanced":0
 },
 {
-"name":"text",
-"default":"",
-"description":"Default text to position at the top center at the image",
-"label":"Image Title",
-"type":"text",
-"advanced":0
-},
-{
 "name":"showTime",
-"default":"1",
+"default":1,
 "description":"Show the current date and time at the top center at the image",
 "label":"Show Time",
 "type":"checkbox",
 "advanced":0
 },
 {
-"name":"showDetails",
-"default":"1",
-"description":"Show image details at the top center at the image",
-"label":"Image Details",
+"name":"timeformat",
+"default":"%Y%m%d %H:%M:%S",
+"description":"Determines the format of the displayed time. Run 'man 3 strftime' to see the options.",
+"label":"Time Format",
+"type":"text",
+"advanced":0
+},
+{
+"name":"showExposure",
+"default":1,
+"description":"Activate to display the exposure length on the overlay.<br>If Auto-Exposure is set, '(auto)' will appear after the exposure time.",
+"label":"Show Exposure",
+"type":"checkbox",
+"advanced":0
+},
+{
+"name":"showGain",
+"default":0,
+"description":"Activate to display the camera gain on the overlay.<br>If Auto-Gain is set, '(auto)' will appear after the gain value.",
+"label":"Show Gain",
+"type":"checkbox",
+"advanced":0
+},
+{
+"name":"showBrightness",
+"default":0,
+"description":"Activate to display the brightness on the overlay.",
+"label":"Show Brightness",
+"type":"checkbox",
+"advanced":0
+},
+{
+"name":"showMean",
+"default":0,
+"description":"Activate to display the mean brightness on the overlay.<br>This is mostly for testing.",
+"label":"Show Mean Brightness",
+"type":"checkbox",
+"advanced":1
+},
+{
+"name":"showFocus",
+"default":0,
+"description":"Activate to display a focus metric to help you focus the camera.",
+"label":"Show Focus Metric",
+"type":"checkbox",
+"advanced":1
+},
+{
+"name":"text",
+"default":"",
+"description":"Text that appears below the optional time with the same color and size.",
+"label":"Text Overlay",
+"type":"text",
+"advanced":0
+},
+{
+"name":"textlineheight",
+"default":30,
+"description":"The line height of the text in pixels. If increasing the font size causes the text to overlap then increase this value.",
+"label":"Line Height",
+"type":"number",
+"advanced":0
+},
+{
+"name":"textx",
+"default":15,
+"description":"Text placement horizontal from LEFT in pixels.",
+"label":"Text X",
+"type":"number",
+"advanced":0
+},
+{
+"name":"texty",
+"default":35,
+"description":"Text placement vertical from TOP in pixels.",
+"label":"Text Y",
+"type":"number",
+"advanced":0
+},
+{
+"name":"fontname",
+"default":"0",
+"description":"Font name for the text overlay. Used for both large and small text.",
+"label":"Font Name",
+"type":"select",
+"options": [
+	{"value": 0, "label": "Simplex"},
+	{"value": 1, "label": "Plain"},
+	{"value": 2, "label": "Duplex"},
+	{"value": 3, "label": "Complex"},
+	{"value": 4, "label": "Triplex"},
+	{"value": 5, "label": "Complex Small"},
+	{"value": 6, "label": "Script Simplex"},
+	{"value": 7, "label": "Script Complex"}
+],
+"advanced":0
+},
+{
+"name":"fontcolor",
+"default":"255 255 255",
+"description":"Blue, Green, and Red (BGR) values of text color. 0 to 255 for each channel.<br>NOTE: When using RAW 16 only the first two values are used i.e., 255 128 0.",
+"label":"Font Color",
+"type":"text",
+"advanced":0
+},
+{
+"name":"smallfontcolor",
+"default":"0 0 255",
+"description":"BGR value of text color. 0 to 255 for each channel.<br>NOTE: When using RAW 16 only the first two values are used i.e., 255 128 0.",
+"label":"Small Font Color",
+"type":"text",
+"advanced":0
+},
+{
+"name":"fonttype",
+"default":0,
+"description":"Choose between smooth font lines (antialiased), 8-pixel, or 4 pixel connectivity (harder edges).",
+"label":"Font Smoothness",
+"type":"select",
+"options": [
+	{"value": 0, "label": "Antialiased"},
+	{"value": 1, "label": "8 connected"},
+	{"value": 2, "label": "4 connected"}
+],
+"advanced":0
+},
+{
+"name":"fontsize",
+"default":7,
+"description":"Text Font Size. The time, if displayed, will use this size; other text displayed will be about 20% smaller.",
+"label":"Font Size",
+"type":"number",
+"advanced":0
+},
+{
+"name":"fontline",
+"default":1,
+"description":"Text Font Line Thickness.",
+"label":"Font Weight",
+"type":"number",
+"advanced":0
+},
+{
+"name":"outlinefont",
+"default":0,
+"description":"Adds a black outline to the text overlay to improve contrast.",
+"label":"Use Outline Font",
 "type":"checkbox",
 "advanced":0
 },
@@ -207,24 +436,8 @@
 "advanced":0
 },
 {
-"name":"fontsize",
-"default":"32",
-"description":"Font size 6 - 160, default value 32",
-"label":"Font Size",
-"type":"number",
-"advanced":0
-},
-{
-"name":"fontcolor",
-"default":"255",
-"description":"Annotation text font color in gray scale value 0 (black) - 255 (white)",
-"label":"Font Color",
-"type":"number",
-"advanced":0
-},
-{
 "name":"background",
-"default":"0",
+"default":0,
 "description":"Background annotation text color in gray scale value 0 (black) - 255 (white)",
 "label":"Background Color",
 "type":"number",
@@ -241,7 +454,7 @@
 },
 {
 "name":"notificationimages",
-"default":"1",
+"default":1,
 "description":"Activate to display notification images, e.g., 'Camera is off during the day'.",
 "label":"Notification Images",
 "type":"checkbox",
@@ -272,16 +485,8 @@
 "advanced":0
 },
 {
-"name":"autofocus",
-"default":"0",
-"description":"Auto Focus",
-"label":"Auto Focus",
-"type":"checkbox",
-"advanced":0
-},
-{
 "name":"debuglevel",
-"default":"0",
+"default":0,
 "description":"Debug level, 0 is lowest level.",
 "label":"Debug Level",
 "type":"select",
@@ -289,21 +494,30 @@
 	{"value": "0", "label": "0"},
 	{"value": "1", "label": "1"},
 	{"value": "2", "label": "2"},
-	{"value": "3", "label": "3"}
+	{"value": "3", "label": "3"},
+	{"value": "4", "label": "4"}
 ],
 "advanced":1
 },
 {
 "name":"darkframe",
-"default":"0",
+"default":0,
 "description":"Capture dark frames",
-"label":"Dark Frame",
+"label":"Capture Dark Frames",
 "type":"checkbox",
 "advanced":0
 },
 {
+"name":"locale",
+"default":"en_US.UTF-8",
+"description":"Your locale, used to determine what the thousands and decimal separators are.<br>Type 'locale' at a command prompt to see your choices (use the LC_NUMERIC entry).",
+"label":"Locale",
+"type":"text",
+"advanced":0
+},
+{
 "name":"alwaysshowadvanced",
-"default":"0",
+"default":0,
 "description":"Activate to always show the advanced options.",
 "label":"Always Show Advanced",
 "type":"checkbox",


### PR DESCRIPTION
Add many entries to make it more like ZWO version.
This is needed now that the RPiHQ version supports text overlay and many new options from the ZWO version.