### PR TITLE
camera_settings.php: reload if possible

### DIFF
--- a/includes/camera_settings.php
+++ b/includes/camera_settings.php
@@ -21,7 +21,7 @@ function DisplayCameraConfig(){
 				fclose($camera_settings_file);
 				$msg = "Camera settings saved";
 				if (isset($_POST['restart'])) {
-					shell_exec("sudo systemctl restart allsky.service");
+					shell_exec("sudo systemctl try-reload-or-restart allsky.service");
 					$msg .= " and service restarted";
 					$status->addMessage($msg);
 				} else {

--- a/includes/camera_settings.php
+++ b/includes/camera_settings.php
@@ -21,7 +21,7 @@ function DisplayCameraConfig(){
 				fclose($camera_settings_file);
 				$msg = "Camera settings saved";
 				if (isset($_POST['restart'])) {
-					shell_exec("sudo systemctl try-reload-or-restart allsky.service");
+					shell_exec("sudo systemctl reload-or-restart allsky.service");
 					$msg .= " and service restarted";
 					$status->addMessage($msg);
 				} else {


### PR DESCRIPTION
* Call "try-reload-or-restart" to call the systemctl "reload" command, and if it fails, the "restart" command.
* Newer Allsky software accepts "reload", which sends SIGHUP to the capture* program to (in the future) have it re-read it settings.