### PR TITLE
Try reload or restart

### DIFF
--- a/includes/camera_settings.php
+++ b/includes/camera_settings.php
@@ -21,7 +21,7 @@ function DisplayCameraConfig(){
 				fclose($camera_settings_file);
 				$msg = "Camera settings saved";
 				if (isset($_POST['restart'])) {
-					shell_exec("sudo systemctl restart allsky.service");
+					shell_exec("sudo systemctl try-reload-or-restart allsky.service");
 					$msg .= " and service restarted";
 					$status->addMessage($msg);
 				} else {

--- a/includes/camera_settings.php
+++ b/includes/camera_settings.php
@@ -21,7 +21,7 @@ function DisplayCameraConfig(){
 				fclose($camera_settings_file);
 				$msg = "Camera settings saved";
 				if (isset($_POST['restart'])) {
-					shell_exec("sudo systemctl try-reload-or-restart allsky.service");
+					shell_exec("sudo systemctl reload-or-restart allsky.service");
 					$msg .= " and service restarted";
 					$status->addMessage($msg);
 				} else {


### PR DESCRIPTION
The "allsky" package is implementing the ability to have the program re-read its configuration variables without exiting and restarting.  It is sent the SIGHUP signal when a "reload" should occur.  It currently just captures that signal and exits, but will eventually re-load arguments (once they are all in one file).

This PR changes the WebUI to cause the SIGHUP signal to be sent by using "systemctl reload-or-restart allsky" (the "reload" part sends the signal, and if that's not supported the "restart" part does a normal restart).