### PR TITLE
Post camera to allsky map

### DIFF
--- a/camera_options_RPiHQ.json
+++ b/camera_options_RPiHQ.json
@@ -295,6 +295,69 @@
 "label":"Always Show Advanced",
 "type":"checkbox",
 "advanced":1
+},
+{
+"name":"",
+"default":"",
+"description":"Camera Setup",
+"label":"",
+"type":"header",
+"advanced":0
+},
+{
+"name":"location",
+"default":"",
+"description":"The location of your camera. Ex: Whitehorse, YT, Canada",
+"label":"Location",
+"type":"text",
+"advanced":0
+},
+{
+"name":"owner",
+"default":"",
+"description":"The owner of the camera. It can be your name or an association or observatory, etc",
+"label":"Owner",
+"type":"text",
+"advanced":0
+},
+{
+"name":"websiteurl",
+"default":"",
+"description":"The URL of your website. ex: https://thomasjacquin.com/allsky",
+"label":"Website URL",
+"type":"text",
+"advanced":0
+},
+{
+"name":"imageurl",
+"default":"",
+"description":"The url or the image on your website. ex: https://thomasjacquin.com/allsky/image.jpg.<br/>Right-click on the image and select Copy Image Address",
+"label":"Image URL",
+"type":"text",
+"advanced":0
+},
+{
+"name":"camera",
+"default":"",
+"description":"The model of your camera. Ex: ASI 224MC or RPiHQ",
+"label":"Camera",
+"type":"text",
+"advanced":0
+},
+{
+"name":"lens",
+"default":"",
+"description":"The lens you're using on your camera. Ex: Arecont 1.55",
+"label":"Lens",
+"type":"text",
+"advanced":0
+},
+{
+"name":"computer",
+"default":"",
+"description":"The computer inside your allsky enclosure. Ex: Raspberry Pi 3",
+"label":"Computer",
+"type":"text",
+"advanced":0
 }
-
 ]

--- a/camera_options_RPiHQ.json
+++ b/camera_options_RPiHQ.json
@@ -297,6 +297,14 @@
 "advanced":1
 },
 {
+"name":"showonmap",
+"default":0,
+"description":"Activate to have your camera showing up on the allsky map. https://www.thomasjacquin.com/allsky-map",
+"label":"Show on Map",
+"type":"checkbox",
+"advanced":0
+},
+{
 "name":"",
 "default":"",
 "description":"Camera Setup",
@@ -323,7 +331,7 @@
 {
 "name":"websiteurl",
 "default":"",
-"description":"The URL of your website. ex: https://thomasjacquin.com/allsky",
+"description":"The URL of your website. ex: https://www.thomasjacquin.com/allsky",
 "label":"Website URL",
 "type":"text",
 "advanced":0
@@ -331,7 +339,7 @@
 {
 "name":"imageurl",
 "default":"",
-"description":"The url or the image on your website. ex: https://thomasjacquin.com/allsky/image.jpg.<br/>Right-click on the image and select Copy Image Address",
+"description":"The url or the image on your website. ex: https://wwww.thomasjacquin.com/allsky/image.jpg.<br/>Right-click on the image and select Copy Image Address",
 "label":"Image URL",
 "type":"text",
 "advanced":0

--- a/camera_options_RPiHQ.json
+++ b/camera_options_RPiHQ.json
@@ -297,19 +297,19 @@
 "advanced":1
 },
 {
-"name":"showonmap",
-"default":0,
-"description":"Activate to have your camera showing up on the allsky map. https://www.thomasjacquin.com/allsky-map",
-"label":"Show on Map",
-"type":"checkbox",
-"advanced":0
-},
-{
 "name":"",
 "default":"",
 "description":"Camera Setup",
 "label":"",
 "type":"header",
+"advanced":0
+},
+{
+"name":"showonmap",
+"default":0,
+"description":"Activate to have your camera showing up on the allsky map. https://www.thomasjacquin.com/allsky-map",
+"label":"Show on Map",
+"type":"checkbox",
 "advanced":0
 },
 {

--- a/camera_options_ZWO.json
+++ b/camera_options_ZWO.json
@@ -566,19 +566,19 @@
 "advanced":1
 },
 {
-"name":"showonmap",
-"default":0,
-"description":"Activate to have your camera showing up on the allsky map. https://www.thomasjacquin.com/allsky-map",
-"label":"Show on Map",
-"type":"checkbox",
-"advanced":0
-},
-{
 "name":"",
 "default":"",
 "description":"Camera Setup",
 "label":"",
 "type":"header",
+"advanced":0
+},
+{
+"name":"showonmap",
+"default":0,
+"description":"Activate to have your camera showing up on the allsky map. https://www.thomasjacquin.com/allsky-map",
+"label":"Show on Map",
+"type":"checkbox",
 "advanced":0
 },
 {

--- a/camera_options_ZWO.json
+++ b/camera_options_ZWO.json
@@ -566,6 +566,14 @@
 "advanced":1
 },
 {
+"name":"showonmap",
+"default":0,
+"description":"Activate to have your camera showing up on the allsky map. https://www.thomasjacquin.com/allsky-map",
+"label":"Show on Map",
+"type":"checkbox",
+"advanced":0
+},
+{
 "name":"",
 "default":"",
 "description":"Camera Setup",
@@ -592,7 +600,7 @@
 {
 "name":"websiteurl",
 "default":"",
-"description":"The URL of your website. ex: https://thomasjacquin.com/allsky",
+"description":"The URL of your website. ex: https://www.thomasjacquin.com/allsky",
 "label":"Website URL",
 "type":"text",
 "advanced":0
@@ -600,7 +608,7 @@
 {
 "name":"imageurl",
 "default":"",
-"description":"The url or the image on your website. ex: https://thomasjacquin.com/allsky/image.jpg.<br/>Right-click on the image and select Copy Image Address",
+"description":"The url or the image on your website. ex: https://wwww.thomasjacquin.com/allsky/image.jpg.<br/>Right-click on the image and select Copy Image Address",
 "label":"Image URL",
 "type":"text",
 "advanced":0

--- a/camera_options_ZWO.json
+++ b/camera_options_ZWO.json
@@ -564,5 +564,69 @@
 "label":"Always Show Advanced",
 "type":"checkbox",
 "advanced":1
+},
+{
+"name":"",
+"default":"",
+"description":"Camera Setup",
+"label":"",
+"type":"header",
+"advanced":0
+},
+{
+"name":"location",
+"default":"",
+"description":"The location of your camera. Ex: Whitehorse, YT, Canada",
+"label":"Location",
+"type":"text",
+"advanced":0
+},
+{
+"name":"owner",
+"default":"",
+"description":"The owner of the camera. It can be your name or an association or observatory, etc",
+"label":"Owner",
+"type":"text",
+"advanced":0
+},
+{
+"name":"websiteurl",
+"default":"",
+"description":"The URL of your website. ex: https://thomasjacquin.com/allsky",
+"label":"Website URL",
+"type":"text",
+"advanced":0
+},
+{
+"name":"imageurl",
+"default":"",
+"description":"The url or the image on your website. ex: https://thomasjacquin.com/allsky/image.jpg.<br/>Right-click on the image and select Copy Image Address",
+"label":"Image URL",
+"type":"text",
+"advanced":0
+},
+{
+"name":"camera",
+"default":"",
+"description":"The model of your camera. Ex: ASI 224MC or RPiHQ",
+"label":"Camera",
+"type":"text",
+"advanced":0
+},
+{
+"name":"lens",
+"default":"",
+"description":"The lens you're using on your camera. Ex: Arecont 1.55",
+"label":"Lens",
+"type":"text",
+"advanced":0
+},
+{
+"name":"computer",
+"default":"",
+"description":"The computer inside your allsky enclosure. Ex: Raspberry Pi 3",
+"label":"Computer",
+"type":"text",
+"advanced":0
 }
 ]


### PR DESCRIPTION
The PR adds settings that are used to post the users' cameras on the [allsky map.](https://www.thomasjacquin.com/allsky-map/).

The following settings have been added under a new header `Camera Setup`:

- showonmap
- location
- owner
- websiteurl
- imageurl
- camera
- lens
- computer 