### PR TITLE
Sunwait fix

### DIFF
--- a/dist/css/custom.css
+++ b/dist/css/custom.css
@@ -393,3 +393,9 @@ select {
 .btn-black		 { background-color: #333333; border-color: #777777; color: white; }
 .btn-black:hover { background-color: #888888; border-color: #000000; color: white; }
 .dark .btn-black { border-color: #ffffff; }
+
+/* Error messages */
+.errorMsg {
+	color: red;
+	font-size: 125%;
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -76,12 +76,16 @@ $nightdelay = $camera_settings_array["nightdelay"] + $x;
 $angle = $camera_settings_array['angle'];
 $lat = $camera_settings_array['latitude'];
 $lon = $camera_settings_array['longitude'];
-exec("sunwait poll exit set angle $angle $lat $lon", $return);
-if ($return[0] == 'DAY') {
+exec("sunwait poll exit set angle $angle $lat $lon", $return, $retval);
+if ($retval == 2) {
 	$delay = $daydelay;
-} else {
+} else if ($retval == 3) {
 	$delay = $nightdelay;
+} else {
+	echo "<p class='errorMsg'>ERROR: 'sunwait' returned exit code $retval so we don't know if it's day or night.</p>";
+	$delay = ($daydelay + $nightdelay) / 2;		// Use the average delay
 }
+
 // Divide by 2 to lessen the delay between a new picture and when we check.
 $delay /= 2;
 


### PR DESCRIPTION
In Bullseye, the default `sunwait` doesn't return "DAY" or "NIGHT", instead, it indicates which one it is via its exit code.  This Buster version does both, so check for exit code instead of returned string.